### PR TITLE
16 extend system store with windowapplication state

### DIFF
--- a/app/components/apps/Files/Files.tsx
+++ b/app/components/apps/Files/Files.tsx
@@ -33,16 +33,16 @@ export default function Files() {
   const { setTitle } = useDesktopStore();
   const { dirHistory, saveDirToHistory } = useSystemStore();
 
-  const [state] = useAppState('files');
+  const [state, setState] = useAppState('files');
 
   const [settings, set] = useAppSettings('files');
   const fileHandler = useFileHandler();
 
-  /**
-   * Navigation state
-   */
-  const [path, setPath] = useState<string[]>(parsePath(state.path ?? '/'));
   const [selected, setSelected] = useState<FSObject | null>(null);
+
+  const path = useMemo(() => parsePath(state.path), [state.path]);
+  const setPath = (path: string[]) =>
+    setState({ ...state, path: `/${path.join('/')}` });
 
   const pwd = useMemo(() => `/${path.join('/')}`, [path]);
   const dir = useDirectory(path);

--- a/app/components/apps/Files/files.init.tsx
+++ b/app/components/apps/Files/files.init.tsx
@@ -1,9 +1,9 @@
 import type { WindowInit } from '~/components/desktop/Window';
-import type { FilesProps } from './Files';
+import { type FilesState, defaultFilesState } from './types';
 
-export const files = (props?: FilesProps): WindowInit => ({
+export const files = (initialState?: FilesState): WindowInit<'files'> => ({
   appType: 'files',
-  appProps: props,
+  appState: initialState ?? defaultFilesState,
 
   title: 'File Explorer',
   icon: 'files',

--- a/app/components/apps/Files/types.ts
+++ b/app/components/apps/Files/types.ts
@@ -13,7 +13,7 @@ export const defaultFilesSettings: FilesSettings = {
 };
 
 export interface FilesState {
-  path?: string;
+  path: string;
 }
 
 export const defaultFilesState: FilesState = {

--- a/app/components/apps/Files/types.ts
+++ b/app/components/apps/Files/types.ts
@@ -11,3 +11,11 @@ export const defaultFilesSettings: FilesSettings = {
   statusBar: true,
   sideBar: 'none',
 };
+
+export interface FilesState {
+  path?: string;
+}
+
+export const defaultFilesState: FilesState = {
+  path: '/',
+};

--- a/app/components/apps/Intro/Intro.tsx
+++ b/app/components/apps/Intro/Intro.tsx
@@ -6,7 +6,7 @@ export default function Intro() {
   const { launch } = useDesktopStore();
 
   const openFolder = (path: string) => {
-    launch(files({ initialPath: path }));
+    launch(files({ path }));
   };
 
   return (

--- a/app/components/apps/Minesweeper/Minesweeper.tsx
+++ b/app/components/apps/Minesweeper/Minesweeper.tsx
@@ -4,7 +4,6 @@ import cn from 'classnames';
 import { useWindow } from '~/components/desktop/Window/context';
 import Menu from '~/components/ui/Menu';
 
-import useDesktopStore from '~/stores/desktop';
 import { useAppSettings } from '~/stores/system';
 
 import { difficultyPresets, newBoard } from './game';
@@ -14,8 +13,7 @@ import MinesweeperStatus from './MinesweeperStatus';
 import MinesweeperCell from './MinesweeperCell';
 
 export default function Minesweeper() {
-  const { close } = useDesktopStore();
-  const { id } = useWindow();
+  const { close } = useWindow();
 
   const [settings, set] = useAppSettings('minesweeper');
 
@@ -112,7 +110,7 @@ export default function Minesweeper() {
 
           <Menu.Separator />
 
-          <Menu.Item label="Exit" onSelect={() => close(id)} />
+          <Menu.Item label="Exit" onSelect={close} />
         </Menu.Root>
       </div>
 

--- a/app/components/apps/Preview/Preview.tsx
+++ b/app/components/apps/Preview/Preview.tsx
@@ -1,9 +1,12 @@
 import { useEffect } from 'react';
-import useDesktopStore from '~/stores/desktop';
-import { useWindow } from '~/components/desktop/Window/context';
-import { PreviewAppProvider, type PreviewSupportedFile } from './context';
+
+import { useAppState, useWindow } from '~/components/desktop/Window/context';
+
+import { PreviewAppProvider } from './context';
+import type { PreviewSupportedFile } from './types';
 import PreviewMarkdown from './modes/PreviewMarkdown';
 import PreviewImage from './modes/PreviewImage';
+import useDesktopStore from '~/stores/desktop';
 
 const getPreviewMode = (fileType: PreviewSupportedFile['type']) => {
   switch (fileType) {
@@ -14,19 +17,16 @@ const getPreviewMode = (fileType: PreviewSupportedFile['type']) => {
   }
 };
 
-export interface PreviewProps {
-  file?: PreviewSupportedFile;
-  filePath?: string;
-}
-
-export default function Preview({ file, filePath }: PreviewProps) {
-  const { setWindowProps } = useDesktopStore();
+export default function Preview() {
   const { id } = useWindow();
+  const { setTitle } = useDesktopStore();
+
+  const [{ file, filePath }] = useAppState('preview');
 
   // Set window title to file title
   useEffect(() => {
-    if (file) setWindowProps(id, { title: `${file.name} - Preview` });
-  }, [setWindowProps, file, id]);
+    if (file) setTitle(id, `${file.name} - Preview`);
+  }, [setTitle, id, file]);
 
   if (!file || !filePath) return null;
 

--- a/app/components/apps/Preview/context.tsx
+++ b/app/components/apps/Preview/context.tsx
@@ -1,9 +1,7 @@
 import type { PropsWithChildren } from 'react';
 import { createContext, useContext } from 'react';
-import type { ImageFile, MarkdownFile } from '~/content/types';
 
-export const previewSupportedFileTypes = ['md', 'image'];
-export type PreviewSupportedFile = MarkdownFile | ImageFile;
+import type { PreviewSupportedFile } from './types';
 
 interface PreviewAppContextType {
   file: PreviewSupportedFile;

--- a/app/components/apps/Preview/modes/PreviewImage.tsx
+++ b/app/components/apps/Preview/modes/PreviewImage.tsx
@@ -5,8 +5,8 @@ import { useWindow } from '~/components/desktop/Window/context';
 import { useEffect, useRef, useState } from 'react';
 import Button from '~/components/ui/Button';
 import { getAppResourcesUrl } from '~/content/utils';
-import useDesktopStore from '~/stores/desktop';
 import Toolbar from '~/components/ui/Toolbar';
+import useDesktopStore from '~/stores/desktop';
 
 const resources = getAppResourcesUrl('preview');
 
@@ -17,8 +17,8 @@ const ZOOM_STOPS = [
 ];
 
 export default function PreviewImage() {
-  const { moveAndResize, close } = useDesktopStore();
-  const { id, minWidth, minHeight } = useWindow();
+  const { id, minWidth, minHeight, close } = useWindow();
+  const { moveAndResize } = useDesktopStore();
 
   const { file, resourceUrl } = usePreviewApp();
   if (file.type !== 'image') throw new Error('Wrong file type');
@@ -120,7 +120,7 @@ export default function PreviewImage() {
 
           <Menu.Separator />
 
-          <Menu.Item label="Close" onSelect={() => close(id)} />
+          <Menu.Item label="Close" onSelect={close} />
         </Menu.Root>
 
         <Menu.Root trigger={<Menu.Trigger>View</Menu.Trigger>}>

--- a/app/components/apps/Preview/preview.init.ts
+++ b/app/components/apps/Preview/preview.init.ts
@@ -1,9 +1,11 @@
 import type { WindowInit } from '~/components/desktop/Window';
-import type { PreviewProps } from './Preview';
+import { type PreviewState, previewDefaultState } from './types';
 
-export const preview = (props?: PreviewProps): WindowInit => ({
+export const preview = (
+  initialState?: PreviewState,
+): WindowInit<'preview'> => ({
   appType: 'preview',
-  appProps: props,
+  appState: initialState ?? previewDefaultState,
 
   title: 'Preview',
   icon: 'preview',

--- a/app/components/apps/Preview/types.ts
+++ b/app/components/apps/Preview/types.ts
@@ -1,0 +1,11 @@
+import type { MarkdownFile, ImageFile } from '~/content/types';
+
+export type PreviewSupportedFile = MarkdownFile | ImageFile;
+export const previewSupportedFileTypes = ['md', 'image'];
+
+export interface PreviewState {
+  file?: PreviewSupportedFile;
+  filePath?: string;
+}
+
+export const previewDefaultState: PreviewState = {};

--- a/app/components/apps/Solitaire/Solitaire.tsx
+++ b/app/components/apps/Solitaire/Solitaire.tsx
@@ -2,7 +2,6 @@ import { forwardRef, useEffect, useReducer, useRef, useState } from 'react';
 import cn from 'classnames';
 
 import { useWindow } from '~/components/desktop/Window/context';
-import useDesktopStore from '~/stores/desktop';
 import Button from '~/components/ui/Button';
 import Menu from '~/components/ui/Menu';
 
@@ -43,8 +42,7 @@ const Card = forwardRef<HTMLImageElement, CardProps>(function Card(
 });
 
 export default function Solitaire() {
-  const { close } = useDesktopStore();
-  const { id } = useWindow();
+  const { close } = useWindow();
 
   const [settings, set] = useAppSettings('solitaire');
   const [game, dispatch] = useReducer(solitaireReducer, deal());
@@ -175,7 +173,7 @@ export default function Solitaire() {
 
           <Menu.Separator />
 
-          <Menu.Item label="Exit" onSelect={() => close(id)} />
+          <Menu.Item label="Exit" onSelect={close} />
         </Menu.Root>
       </div>
 

--- a/app/components/apps/Sudoku/Sudoku.tsx
+++ b/app/components/apps/Sudoku/Sudoku.tsx
@@ -7,7 +7,6 @@ import Button from '~/components/ui/Button';
 import { useWindow } from '~/components/desktop/Window/context';
 import { useFetcher } from '@remix-run/react';
 import Markdown from '~/components/ui/Markdown';
-import useDesktopStore from '~/stores/desktop';
 import Toolbar from '~/components/ui/Toolbar';
 import { useAppSettings } from '~/stores/system';
 
@@ -107,8 +106,7 @@ function SudokuCell({ index: i, value, fixed, game, dispatch }: CellProps) {
 }
 
 export default function Sudoku() {
-  const { close } = useDesktopStore();
-  const { id } = useWindow();
+  const { close } = useWindow();
 
   const [settings, set] = useAppSettings('sudoku');
 
@@ -218,7 +216,7 @@ export default function Sudoku() {
 
           <Menu.Separator />
 
-          <Menu.Item label="Exit" onSelect={() => close(id)} />
+          <Menu.Item label="Exit" onSelect={close} />
         </Menu.Root>
       </div>
 

--- a/app/components/apps/renderApp.tsx
+++ b/app/components/apps/renderApp.tsx
@@ -1,7 +1,9 @@
 import About, { about } from './About';
 import Intro, { intro } from './Intro';
 import Files, { files } from './Files';
+import type { FilesState } from './Files/types';
 import Preview, { preview } from './Preview';
+import type { PreviewState } from './Preview/types';
 import Minesweeper, { minesweeper } from './Minesweeper';
 import Sudoku, { sudoku } from './Sudoku';
 import Solitaire, { solitaire } from './Solitaire';
@@ -16,17 +18,24 @@ const applications = [
   { Component: Sudoku, meta: sudoku },
 ];
 
-interface AppOutletProps {
-  type: string;
-  props?: unknown;
+interface AppStateTypes {
+  files: FilesState;
+  preview: PreviewState;
 }
 
-export default function AppOutlet({ type, props }: AppOutletProps) {
+export type AppState<AppType extends string> =
+  AppType extends keyof AppStateTypes ? AppStateTypes[AppType] : undefined;
+
+interface AppOutletProps {
+  type: string;
+}
+
+export default function AppOutlet({ type }: AppOutletProps) {
   const app = applications.find(({ meta }) => meta.appType === type);
   if (!app) return <div>Unknown application {type}</div>;
 
   const { Component } = app;
-  return <Component {...(props as React.ComponentProps<typeof Component>)} />;
+  return <Component />;
 }
 
 export function getApp(type: string) {

--- a/app/components/desktop/StartMenu.tsx
+++ b/app/components/desktop/StartMenu.tsx
@@ -52,7 +52,7 @@ export default function StartMenu() {
                 />
               ))}
             </Menu.Sub>
-            {[files({ initialPath: '/Documents' }), about, intro].map((app) => (
+            {[files({ path: '/Documents' }), about, intro].map((app) => (
               <Menu.Item
                 key={app.appType}
                 label={app.title ?? ''}
@@ -69,7 +69,7 @@ export default function StartMenu() {
             <Menu.Item
               label="My Documents"
               icon="/fs/system/Applications/files/icon_16.png"
-              onSelect={() => launch(files({ initialPath: '/Documents' }))}
+              onSelect={() => launch(files({ path: '/Documents' }))}
             />
 
             <Menu.Separator />

--- a/app/components/desktop/Window/Window.tsx
+++ b/app/components/desktop/Window/Window.tsx
@@ -3,7 +3,7 @@ import useMoveWindow from './useMoveWindow';
 import useResizeWindow from './useResizeWindow';
 import cn from 'classnames';
 import Button from '~/components/ui/Button';
-import AppOutlet from '~/components/apps/renderApp';
+import AppOutlet, { type AppState } from '~/components/apps/renderApp';
 import { WindowProvider } from './context';
 import useDesktopStore from '~/stores/desktop';
 
@@ -15,10 +15,10 @@ export enum WindowSizingMode {
   MAX_CONTENT = 'max-content',
 }
 
-export interface WindowProps {
+export interface WindowProps<AppType extends string> {
   id: string;
-  appType: string;
-  appProps?: unknown;
+  appType: AppType;
+  appState: AppState<AppType>;
 
   // Decoration
   title: string;
@@ -49,11 +49,13 @@ export interface WindowProps {
   maximizable: boolean;
 }
 
-export type WindowInit = Omit<
-  Partial<WindowProps>,
-  'id' | 'focused' | 'order' | 'appType'
+export type WindowInit<AppType extends string> = Omit<
+  Partial<WindowProps<AppType>>,
+  'id' | 'focused' | 'order'
 > &
-  Pick<WindowProps, 'appType'>;
+  Pick<WindowProps<AppType>, 'appType' | 'appState'>;
+
+export type AnyWindowProps = WindowProps<string>;
 
 function getSizeValue(mode: WindowSizingMode, value: number) {
   if (mode === WindowSizingMode.AUTO) return 'auto';
@@ -62,7 +64,7 @@ function getSizeValue(mode: WindowSizingMode, value: number) {
   return `${value}px`;
 }
 
-function getWindowStyleProps({
+function getWindowStyleProps<AppType extends string>({
   top,
   left,
   width,
@@ -71,7 +73,7 @@ function getWindowStyleProps({
   sizingY,
   maximized,
   order,
-}: WindowProps) {
+}: WindowProps<AppType>) {
   if (maximized)
     return {
       top: '0',
@@ -90,8 +92,8 @@ function getWindowStyleProps({
   };
 }
 
-export default function Window(props: WindowProps) {
-  const { id, appType, appProps, title, maximized, focused } = props;
+export default function Window<T extends string>(props: WindowProps<T>) {
+  const { id, appType, title, maximized, focused } = props;
   const { focus, close, toggleMaximized } = useDesktopStore();
 
   /**
@@ -240,8 +242,8 @@ export default function Window(props: WindowProps) {
           </div>
         </div>
 
-        <WindowProvider value={props}>
-          <AppOutlet type={appType} props={appProps} />
+        <WindowProvider windowProps={props}>
+          <AppOutlet type={appType} />
         </WindowProvider>
       </div>
 

--- a/app/components/desktop/Window/context.tsx
+++ b/app/components/desktop/Window/context.tsx
@@ -1,22 +1,60 @@
 import type { PropsWithChildren } from 'react';
 import { createContext, useContext } from 'react';
 
+import useDesktopStore from '~/stores/desktop';
+import type { AppState } from '~/components/apps/renderApp';
 import type { WindowProps } from './Window';
 
-const WindowContext = createContext<WindowProps>({} as WindowProps);
+interface WindowContextType<T extends string> extends WindowProps<T> {
+  focus: () => void;
+  toggleMaximized: () => void;
+  close: () => void;
+}
 
-type ProviderProps = PropsWithChildren<{ value: WindowProps }>;
+const WindowContext = createContext<WindowContextType<string>>(
+  {} as WindowContextType<string>,
+);
 
-export function WindowProvider({ value, children }: ProviderProps) {
+type ProviderProps<T extends string> = PropsWithChildren<{
+  windowProps: WindowProps<T>;
+}>;
+
+export function WindowProvider<T extends string>({
+  windowProps,
+  children,
+}: ProviderProps<T>) {
+  const desktop = useDesktopStore();
+
+  const focus = () => desktop.focus(windowProps.id);
+  const toggleMaximized = () => desktop.toggleMaximized(windowProps.id);
+  const close = () => desktop.close(windowProps.id);
+
+  const value = { ...windowProps, focus, toggleMaximized, close };
+
   return (
     <WindowContext.Provider value={value}>{children}</WindowContext.Provider>
   );
 }
 
-export function useWindow() {
+export function useWindow<T extends string>(appType?: T) {
   const context = useContext(WindowContext);
   if (!context)
     throw new Error('useWindow() must be used inside Window context');
 
-  return context;
+  if (appType && context.appType !== appType)
+    throw new Error(
+      `useWindow() expected app ${appType}, but is being called inside app ${context.appType}`,
+    );
+
+  return context as WindowContextType<T>;
+}
+
+export function useAppState<T extends string>(appType: T) {
+  const { setWindowProps } = useDesktopStore();
+  const { appState, id } = useWindow(appType);
+
+  const setState = (state: AppState<T>) =>
+    setWindowProps(id, { appState: state });
+
+  return [appState, setState] as const;
 }

--- a/app/components/desktop/Window/useMoveWindow.ts
+++ b/app/components/desktop/Window/useMoveWindow.ts
@@ -1,9 +1,9 @@
 import useDesktopStore from '~/stores/desktop';
-import type { WindowProps } from './Window';
+import type { AnyWindowProps } from './Window';
 import useDrag from '~/hooks/useDrag';
 
 export default function useMoveWindow(
-  { id, maximized }: WindowProps,
+  { id, maximized }: AnyWindowProps,
   windowRef: React.RefObject<HTMLDivElement>,
 ) {
   const { moveAndResize } = useDesktopStore();

--- a/app/components/desktop/Window/useResizeWindow.ts
+++ b/app/components/desktop/Window/useResizeWindow.ts
@@ -1,10 +1,10 @@
 import useDesktopStore from '~/stores/desktop';
-import type { WindowProps } from './Window';
+import type { AnyWindowProps } from './Window';
 import useDrag from '~/hooks/useDrag';
 import clamp from '~/utils/clamp';
 
 export default function useResizeWindow(
-  { id, minWidth, minHeight, maxWidth, maxHeight }: WindowProps,
+  { id, minWidth, minHeight, maxWidth, maxHeight }: AnyWindowProps,
   windowRef: React.RefObject<HTMLDivElement>,
   direction: 'n' | 'ne' | 'e' | 'se' | 's' | 'sw' | 'w' | 'nw',
 ) {

--- a/app/hooks/useFileHandler.ts
+++ b/app/hooks/useFileHandler.ts
@@ -2,7 +2,7 @@ import { preview } from '~/components/apps/Preview';
 import {
   type PreviewSupportedFile,
   previewSupportedFileTypes,
-} from '~/components/apps/Preview/context';
+} from '~/components/apps/Preview/types';
 import { getApp } from '~/components/apps/renderApp';
 import type { AnyFile } from '~/content/types';
 import useDesktopStore from '~/stores/desktop';

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -17,3 +17,13 @@ export default function Index() {
 
   return mounted ? <Desktop /> : null;
 }
+
+export function ErrorBoundary() {
+  return (
+    <div className="my-6 mx-auto w-full max-w-lg border border-[red] p-4">
+      A system error ocurred... The most likely cause is stale data from an
+      older version of this app. Please delete all site data and refresh the
+      page.
+    </div>
+  );
+}

--- a/app/stores/desktop.ts
+++ b/app/stores/desktop.ts
@@ -8,6 +8,9 @@ import type { WindowProps, WindowInit } from '../components/desktop/Window';
 import { WindowSizingMode } from '../components/desktop/Window';
 import clamp from '~/utils/clamp';
 
+// Schema version, ensures incompatible data isn't loaded
+// CHANGING THIS WILL WIPE ALL DATA FOR EVERYONE.
+// Update ONLY for breaking changes to the schema.
 const SCHEMA_VERSION = 1;
 
 const defaultWindowProps = {

--- a/app/stores/desktop.ts
+++ b/app/stores/desktop.ts
@@ -1,8 +1,11 @@
 import { nanoid } from 'nanoid';
-import type { WindowProps, WindowInit } from '../components/desktop/Window';
-import { WindowSizingMode } from '../components/desktop/Window';
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
+import merge from 'ts-deepmerge';
+
+import type { AnyWindowProps } from '~/components/desktop/Window/Window';
+import type { WindowProps, WindowInit } from '../components/desktop/Window';
+import { WindowSizingMode } from '../components/desktop/Window';
 import clamp from '~/utils/clamp';
 
 const defaultWindowProps = {
@@ -27,11 +30,11 @@ const defaultWindowProps = {
   maximizable: true,
 };
 
-function createWindow(props: WindowInit): WindowProps {
+function createWindow<T extends string>(init: WindowInit<T>): WindowProps<T> {
   const window = {
     id: nanoid(),
     ...defaultWindowProps,
-    ...props,
+    ...init,
   };
 
   const desktopEl = document.querySelector('#desktop') as HTMLDivElement;
@@ -58,23 +61,27 @@ function createWindow(props: WindowInit): WindowProps {
   return window;
 }
 
-type WindowSizeProps = Partial<
-  Pick<WindowProps, 'top' | 'left' | 'width' | 'height'>
+export type WindowSizeProps = Partial<
+  Pick<AnyWindowProps, 'top' | 'left' | 'width' | 'height'>
 >;
 
 interface DesktopState {
-  windows: WindowProps[];
+  windows: AnyWindowProps[];
   shutdownDialog: boolean;
 }
 
 interface DesktopActions {
   // Window-related actions
-  launch: (init: WindowInit) => void;
+  launch: <T extends string>(init: WindowInit<T>) => void;
   focus: (id: string) => void;
   toggleMaximized: (id: string) => void;
   close: (id: string) => void;
   moveAndResize: (id: string, data: WindowSizeProps) => void;
-  setWindowProps: (id: string, data: Partial<WindowProps>) => void;
+  setTitle: (id: string, title: string) => void;
+  setWindowProps: <T extends string>(
+    id: string,
+    data: Partial<WindowProps<T>>,
+  ) => void;
 
   // Other actions
   shutdown: (open?: boolean) => void;
@@ -144,6 +151,12 @@ const useDesktopStore = create<DesktopState & DesktopActions>()(
             window.id === id ? { ...window, ...data } : window,
           ),
         })),
+      setTitle: (id, title) =>
+        set(({ windows }) => ({
+          windows: windows.map((window) =>
+            window.id === id ? { ...window, title } : window,
+          ),
+        })),
       setWindowProps: (id, data) =>
         set(({ windows }) => ({
           windows: windows.map((window) =>
@@ -152,7 +165,17 @@ const useDesktopStore = create<DesktopState & DesktopActions>()(
         })),
       shutdown: (open = false) => set(() => ({ shutdownDialog: open })),
     }),
-    { name: 'desktop-storage' },
+    {
+      name: 'desktop-storage',
+      merge: (persisted, current) =>
+        // We'll assume the persisted state is valid and hasn't been tampered
+        // with, otherwise making this type-safe is a nightmare
+        merge.withOptions(
+          { mergeArrays: false },
+          current,
+          persisted as typeof current,
+        ) as any,
+    },
   ),
 );
 

--- a/app/stores/system.ts
+++ b/app/stores/system.ts
@@ -25,6 +25,8 @@ import {
 const MAX_FILE_HISTORY = 10; // Number of last accessed files to keep
 const MAX_DIR_HISTORY = 10; // Number of last accessed directories to keep
 
+const SCHEMA_VERSION = 1;
+
 export interface FileAccess {
   time: number;
   path: string;
@@ -46,6 +48,8 @@ interface SystemState {
   };
   fileHistory: FileAccess[];
   dirHistory: DirectoryAccess[];
+
+  _schema: number;
 }
 
 type AppWithSettings = keyof SystemState['appSettings'];
@@ -84,6 +88,8 @@ const useSystemStore = create<SystemState & SystemActions>()(
       fileHistory: [],
       dirHistory: [],
 
+      _schema: SCHEMA_VERSION,
+
       /**
        * Actions
        */
@@ -116,14 +122,21 @@ const useSystemStore = create<SystemState & SystemActions>()(
     }),
     {
       name: 'system-storage',
-      merge: (persisted, current) =>
+      merge: (persisted, current) => {
+        // Wipe persisted state on schema version change
+        // This will allow me to safely introduce breaking schema changes
+        // without causing the app to crash for existing users
+        if ((persisted as typeof current)._schema !== current._schema)
+          return current;
+
         // We'll assume the persisted state is valid and hasn't been tampered
         // with, otherwise making this type-safe is a nightmare
-        merge.withOptions(
+        return merge.withOptions(
           { mergeArrays: false },
           current,
           persisted as typeof current,
-        ) as any,
+        ) as any;
+      },
     },
   ),
 );

--- a/app/stores/system.ts
+++ b/app/stores/system.ts
@@ -25,6 +25,9 @@ import {
 const MAX_FILE_HISTORY = 10; // Number of last accessed files to keep
 const MAX_DIR_HISTORY = 10; // Number of last accessed directories to keep
 
+// Schema version, ensures incompatible data isn't loaded
+// CHANGING THIS WILL WIPE ALL DATA FOR EVERYONE.
+// Update ONLY for breaking changes to the schema.
 const SCHEMA_VERSION = 1;
 
 export interface FileAccess {


### PR DESCRIPTION
- Application state can now be stored in the desktop store as part of a window's state, replacing the old `appProps` which was only used to set initial props
- Added a new hook `useAppState` to easily get/update app state
- Introduced schema versioning to Zustand stores, so I can make breaking changes without causing crashes when the app loads data from a previous version. **Updating this will wipe all data for everyone.**